### PR TITLE
displaying success or failed api calls separately

### DIFF
--- a/Contributers.md
+++ b/Contributers.md
@@ -1,0 +1,1 @@
+Rohan Jangotra

--- a/Contributers.md
+++ b/Contributers.md
@@ -1,1 +1,1 @@
-Rohan Jangotra
+Rohan Jangotra- rohanjangotra03794@gmail.com

--- a/flask_monitoringdashboard/controllers/profiler.py
+++ b/flask_monitoringdashboard/controllers/profiler.py
@@ -18,7 +18,7 @@ def get_profiler_table(db_session, endpoint_id, offset, per_page, sortby='latest
     :param offset: number of items that are skipped
     :param per_page: number of items that are returned (at most)
     """
-    table = get_profiled_requests(db_session, endpoint_id, sortby, offset, per_page)
+    table = get_profiled_requests(db_session, endpoint_id, offset, per_page, sortby)
 
     for idx, row in enumerate(table):
         row.time_requested = to_local_datetime(row.time_requested)

--- a/flask_monitoringdashboard/controllers/profiler.py
+++ b/flask_monitoringdashboard/controllers/profiler.py
@@ -11,14 +11,14 @@ from flask_monitoringdashboard.database.stack_line import (
 )
 
 
-def get_profiler_table(db_session, endpoint_id, offset, per_page, sortby='latest'):
+def get_profiler_table(db_session, endpoint_id, offset, per_page, sortby='latest', response_status='all'):
     """
     :param db_session: session for the database
     :param endpoint_id: endpoint to filter on
     :param offset: number of items that are skipped
     :param per_page: number of items that are returned (at most)
     """
-    table = get_profiled_requests(db_session, endpoint_id, offset, per_page, sortby)
+    table = get_profiled_requests(db_session, endpoint_id, offset, per_page, sortby, response_status)
 
     for idx, row in enumerate(table):
         row.time_requested = to_local_datetime(row.time_requested)

--- a/flask_monitoringdashboard/controllers/profiler.py
+++ b/flask_monitoringdashboard/controllers/profiler.py
@@ -11,14 +11,14 @@ from flask_monitoringdashboard.database.stack_line import (
 )
 
 
-def get_profiler_table(db_session, endpoint_id, offset, per_page):
+def get_profiler_table(db_session, endpoint_id, offset, per_page, sortby='latest'):
     """
     :param db_session: session for the database
     :param endpoint_id: endpoint to filter on
     :param offset: number of items that are skipped
     :param per_page: number of items that are returned (at most)
     """
-    table = get_profiled_requests(db_session, endpoint_id, offset, per_page)
+    table = get_profiled_requests(db_session, endpoint_id, sortby, offset, per_page)
 
     for idx, row in enumerate(table):
         row.time_requested = to_local_datetime(row.time_requested)

--- a/flask_monitoringdashboard/core/config/__init__.py
+++ b/flask_monitoringdashboard/core/config/__init__.py
@@ -34,6 +34,7 @@ class Config(object):
         self.outlier_detection_constant = 2.5
         self.sampling_period = 5 / 1000.0
         self.enable_logging = False
+        self.enable_param_logs = False
 
         # database
         self.database_name = 'sqlite:///flask_monitoringdashboard.db'

--- a/flask_monitoringdashboard/core/profiler/__init__.py
+++ b/flask_monitoringdashboard/core/profiler/__init__.py
@@ -51,11 +51,17 @@ def start_outlier_thread(endpoint):
 
 def start_profiler_and_outlier_thread(endpoint):
     """ Starts two threads: PerformanceProfiler and StacktraceProfiler.  """
+    import json
     current_thread = threading.current_thread().ident
     ip = request.environ['REMOTE_ADDR']
     group_by = get_group_by()
+    request_data = {
+        'Headers': request.headers,
+        'Params': request.args.to_dict(),
+        'Payload': json.loads(request.data) if request.data else {}
+    }
     outlier = OutlierProfiler(current_thread, endpoint, ip, group_by)
-    thread = StacktraceProfiler(current_thread, endpoint, ip, group_by, outlier)
+    thread = StacktraceProfiler(current_thread, endpoint, ip, group_by, request_data, outlier)
     thread.start()
     outlier.start()
     return thread

--- a/flask_monitoringdashboard/core/profiler/stacktraceProfiler.py
+++ b/flask_monitoringdashboard/core/profiler/stacktraceProfiler.py
@@ -140,7 +140,7 @@ class StacktraceProfiler(threading.Thread):
                         position=position,
                         indent=2,
                         duration=self._duration,
-                        code_line=((fn, count, 'None', f'{k}:{v}')),
+                        code_line=((fn, count, 'None', '{}:{}'.format(k,v))),
                     )
                     position += 1
         return position

--- a/flask_monitoringdashboard/core/profiler/stacktraceProfiler.py
+++ b/flask_monitoringdashboard/core/profiler/stacktraceProfiler.py
@@ -24,7 +24,7 @@ class StacktraceProfiler(threading.Thread):
     This is used when monitoring-level == 2 and monitoring-level == 3
     """
 
-    def __init__(self, thread_to_monitor, endpoint, ip, group_by, request_data, outlier_profiler=None):
+    def __init__(self, thread_to_monitor, endpoint, ip, group_by, request_data= {}, outlier_profiler=None):
         threading.Thread.__init__(self)
         self._keeprunning = True
         self._thread_to_monitor = thread_to_monitor

--- a/flask_monitoringdashboard/core/profiler/stacktraceProfiler.py
+++ b/flask_monitoringdashboard/core/profiler/stacktraceProfiler.py
@@ -113,25 +113,36 @@ class StacktraceProfiler(threading.Thread):
         count = 0
         position = 0
         for key, value in self._request_data.items():
-            if value:
+            if position == 0:
                 add_stack_line(
                     db_session,
                     request_id,
                     position=position,
                     indent=0,
                     duration=self._duration,
-                    code_line=((fn, count, 'None', key)),
+                    code_line=((fn, count, 'None', 'Request Parameters')),
                 )
-
+                position += 1
+            if value:
                 add_stack_line(
                     db_session,
                     request_id,
-                    position=position + 1,
+                    position=position,
                     indent=1,
                     duration=self._duration,
-                    code_line=((fn, count, 'None', str(value))),
+                    code_line=((fn, count, 'None', key)),
                 )
-                position += 2
+                position += 1
+                for k, v in value.items():
+                    add_stack_line(
+                        db_session,
+                        request_id,
+                        position=position,
+                        indent=2,
+                        duration=self._duration,
+                        code_line=((fn, count, 'None', f'{k}:{v}')),
+                    )
+                    position += 1
         return position
 
     def insert_lines_db(self, db_session, request_id):

--- a/flask_monitoringdashboard/core/profiler/stacktraceProfiler.py
+++ b/flask_monitoringdashboard/core/profiler/stacktraceProfiler.py
@@ -24,13 +24,13 @@ class StacktraceProfiler(threading.Thread):
     This is used when monitoring-level == 2 and monitoring-level == 3
     """
 
-    def __init__(self, thread_to_monitor, endpoint, ip, group_by, request_data= {}, outlier_profiler=None):
+    def __init__(self, thread_to_monitor, endpoint, ip, group_by, request_data= None, outlier_profiler=None):
         threading.Thread.__init__(self)
         self._keeprunning = True
         self._thread_to_monitor = thread_to_monitor
         self._endpoint = endpoint
         self._ip = ip
-        self._request_data = request_data
+        self._request_data = request_data or {}
         self._group_by = group_by
         self._duration = 0
         self._histogram = defaultdict(float)
@@ -103,6 +103,10 @@ class StacktraceProfiler(threading.Thread):
                 self._outlier_profiler.add_outlier(request_id)
 
     def insert_request_params_db(self, db_session, request_id):
+        """
+        Used for saving API request parameters
+        If config.enable_param_logs is set to True
+        """
         try:
             fun = config.app.view_functions[self._endpoint.name]
         except AttributeError:

--- a/flask_monitoringdashboard/database/__init__.py
+++ b/flask_monitoringdashboard/database/__init__.py
@@ -50,9 +50,9 @@ class Request(Base):
     id = Column(Integer, primary_key=True)
     endpoint_id = Column(Integer, ForeignKey(Endpoint.id))
     # the processing time of the request
-    duration = Column(Float, nullable=False)
+    duration = Column(Float, nullable=False, index=True)
     # the time when the request was handled
-    time_requested = Column(DateTime, default=datetime.datetime.utcnow)
+    time_requested = Column(DateTime, default=datetime.datetime.utcnow, index=True)
     # the version when the request was handled
     version_requested = Column(String(100), default=config.version)
     # a criteria by which the requests can be grouped

--- a/flask_monitoringdashboard/database/stack_line.py
+++ b/flask_monitoringdashboard/database/stack_line.py
@@ -32,7 +32,7 @@ def add_stack_line(db_session, request_id, position, indent, duration, code_line
     )
 
 
-def get_profiled_requests(db_session, endpoint_id, offset, per_page):
+def get_profiled_requests(db_session, endpoint_id, sortby, offset, per_page):
     """
     Gets the requests of an endpoint sorted by request time, together with the stack lines.
     :param db_session: session for the database
@@ -42,12 +42,16 @@ def get_profiled_requests(db_session, endpoint_id, offset, per_page):
     :return: A list with tuples. Each tuple consists first of a Request-object, and the second part
     of the tuple is a list of StackLine-objects.
     """
+    if sortby == "duration":
+        sortkey = Request.duration
+    else:
+        sortkey = Request.time_requested
     result = (
         db_session.query(Request)
         .filter(Request.endpoint_id == endpoint_id)
         .options(joinedload(Request.stack_lines).joinedload(StackLine.code))
         .filter(Request.stack_lines.any())
-        .order_by(desc(Request.time_requested))
+        .order_by(desc(sortkey))
         .offset(offset)
         .limit(per_page)
         .all()

--- a/flask_monitoringdashboard/database/stack_line.py
+++ b/flask_monitoringdashboard/database/stack_line.py
@@ -32,7 +32,7 @@ def add_stack_line(db_session, request_id, position, indent, duration, code_line
     )
 
 
-def get_profiled_requests(db_session, endpoint_id, sortby, offset, per_page):
+def get_profiled_requests(db_session, endpoint_id, offset, per_page, sortby="time_requested"):
     """
     Gets the requests of an endpoint sorted by request time, together with the stack lines.
     :param db_session: session for the database
@@ -42,16 +42,12 @@ def get_profiled_requests(db_session, endpoint_id, sortby, offset, per_page):
     :return: A list with tuples. Each tuple consists first of a Request-object, and the second part
     of the tuple is a list of StackLine-objects.
     """
-    if sortby == "duration":
-        sortkey = Request.duration
-    else:
-        sortkey = Request.time_requested
     result = (
         db_session.query(Request)
         .filter(Request.endpoint_id == endpoint_id)
         .options(joinedload(Request.stack_lines).joinedload(StackLine.code))
         .filter(Request.stack_lines.any())
-        .order_by(desc(sortkey))
+        .order_by(desc(getattr(Request, sortby)))
         .offset(offset)
         .limit(per_page)
         .all()

--- a/flask_monitoringdashboard/static/elements/pagination.html
+++ b/flask_monitoringdashboard/static/elements/pagination.html
@@ -17,6 +17,27 @@
                 &nbsp;&nbsp;(Sorted by: <strong> {{ pagination.showValue }}</strong>)
             </div>
         </div>
+        <div class="pagination" style="float: left;">
+            <h6>API Status Code:</h6>&nbsp;&nbsp;
+            <div>
+                <a href="#" ng-click="pagination.updateStatusCode('all')">All</a>
+            </div>
+            <div>
+                <h6>|</h6>
+            </div>
+            <div>
+                <a href="#" ng-click="pagination.updateStatusCode('success')">Success</a>
+            </div>
+            <div>
+                <h6>|</h6>
+            </div>
+            <div>
+                <a href="#" ng-click="pagination.updateStatusCode('failed')">Failed</a>
+            </div>
+            <div>
+                &nbsp;&nbsp;(Displaying: <strong> {{ pagination.response_status }}</strong>)
+            </div>
+        </div>
     </div>
     <div class="col-sm-6">
         <ul class="pagination" style="float: right;">

--- a/flask_monitoringdashboard/static/elements/pagination.html
+++ b/flask_monitoringdashboard/static/elements/pagination.html
@@ -2,22 +2,20 @@
     <div class="col-sm-6">
         Displaying <strong>{{ pagination.getLeft() + 1 }}
         - {{ pagination.getRight() }}</strong> {{ pagination.name }}: <strong>{{ pagination.total | number }}</strong> in total
-        <div>
-            <ul class="pagination" style="float: left;">
-                <h6>Sort By:</h6>&nbsp;&nbsp;
-                <div ng-class="{'disabled': pagination.sortby == 'latest'}">
-                    <a href="#" ng-click="pagination.updatesort('latest')">Latest</a>
-                </div>
-                <div>
-                    <h6>|</h6>
-                </div>
-                <div ng-class="{'disabled': pagination.sortby == 'duration'}">
-                    <a href="#" ng-click="pagination.updatesort('duration')">Duration</a>
-                </div>
-                <div>
-                    &nbsp;&nbsp;(Sorted by: <strong> {{ pagination.sortby }}</strong>)
-                </div>
-            </ul>
+        <div class="pagination" style="float: left;">
+            <h6>Sort By:</h6>&nbsp;&nbsp;
+            <div>
+                <a href="#" ng-click="pagination.updatesort('time_requested', 'Latest')">Latest</a>
+            </div>
+            <div>
+                <h6>|</h6>
+            </div>
+            <div>
+                <a href="#" ng-click="pagination.updatesort('duration', 'Duration')">Duration</a>
+            </div>
+            <div>
+                &nbsp;&nbsp;(Sorted by: <strong> {{ pagination.showValue }}</strong>)
+            </div>
         </div>
     </div>
     <div class="col-sm-6">

--- a/flask_monitoringdashboard/static/elements/pagination.html
+++ b/flask_monitoringdashboard/static/elements/pagination.html
@@ -17,6 +17,17 @@
                 ng-class="{'disabled': pagination.page == pagination.getLastPage()}">
                 <a href="#" class="page-link" ng-click="pagination.goto(pagination.page+1)">Next</a>
             </li>
+            <li>
+                <h6 class="page-link">Sort By:</h6>
+            </li>
+            <li class="paginate_button page-item previous"
+                ng-class="{'disabled': pagination.sortby == 'latest'}">
+                <a href="#" class="page-link" ng-click="pagination.updatesort('latest')">Latest</a>
+            </li>
+            <li class="paginate_button page-item next"
+                ng-class="{'disabled': pagination.sortby == 'duration'}">
+                <a href="#" class="page-link" ng-click="pagination.updatesort('duration')">Duration</a>
+            </li>
         </ul>
     </div>
 </div>

--- a/flask_monitoringdashboard/static/elements/pagination.html
+++ b/flask_monitoringdashboard/static/elements/pagination.html
@@ -2,6 +2,23 @@
     <div class="col-sm-6">
         Displaying <strong>{{ pagination.getLeft() + 1 }}
         - {{ pagination.getRight() }}</strong> {{ pagination.name }}: <strong>{{ pagination.total | number }}</strong> in total
+        <div>
+            <ul class="pagination" style="float: left;">
+                <h6>Sort By:</h6>&nbsp;&nbsp;
+                <div ng-class="{'disabled': pagination.sortby == 'latest'}">
+                    <a href="#" ng-click="pagination.updatesort('latest')">Latest</a>
+                </div>
+                <div>
+                    <h6>|</h6>
+                </div>
+                <div ng-class="{'disabled': pagination.sortby == 'duration'}">
+                    <a href="#" ng-click="pagination.updatesort('duration')">Duration</a>
+                </div>
+                <div>
+                    &nbsp;&nbsp;(Sorted by: <strong> {{ pagination.sortby }}</strong>)
+                </div>
+            </ul>
+        </div>
     </div>
     <div class="col-sm-6">
         <ul class="pagination" style="float: right;">
@@ -16,17 +33,6 @@
             <li class="paginate_button page-item next"
                 ng-class="{'disabled': pagination.page == pagination.getLastPage()}">
                 <a href="#" class="page-link" ng-click="pagination.goto(pagination.page+1)">Next</a>
-            </li>
-            <li>
-                <h6 class="page-link">Sort By:</h6>
-            </li>
-            <li class="paginate_button page-item previous"
-                ng-class="{'disabled': pagination.sortby == 'latest'}">
-                <a href="#" class="page-link" ng-click="pagination.updatesort('latest')">Latest</a>
-            </li>
-            <li class="paginate_button page-item next"
-                ng-class="{'disabled': pagination.sortby == 'duration'}">
-                <a href="#" class="page-link" ng-click="pagination.updatesort('duration')">Duration</a>
             </li>
         </ul>
     </div>

--- a/flask_monitoringdashboard/static/elements/pagination.html
+++ b/flask_monitoringdashboard/static/elements/pagination.html
@@ -18,7 +18,7 @@
             </div>
         </div>
         <div class="pagination" style="float: left;">
-            <h6>API Status Code:</h6>&nbsp;&nbsp;
+            <h6>Response Code:</h6>&nbsp;&nbsp;
             <div>
                 <a href="#" ng-click="pagination.updateStatusCode('all')">All</a>
             </div>

--- a/flask_monitoringdashboard/static/js/controllers/endpointProfiler.js
+++ b/flask_monitoringdashboard/static/js/controllers/endpointProfiler.js
@@ -16,7 +16,7 @@ function EndpointProfilerController($scope, $http, menuService, endpointService,
     paginationService.onReload = function () {
         formService.isLoading = true;
         $http.get('api/profiler_table/' + endpointService.info.id + '/' +
-            paginationService.getLeft() + '/' + paginationService.perPage + '?sortby='+ paginationService.sortby ).then(function (response) {
+            paginationService.getLeft() + '/' + paginationService.perPage + '?sortby='+ paginationService.sortby + '&response_status='+ paginationService.response_status ).then(function (response) {
             $scope.table = response.data;
             formService.isLoading = false;
             // Add more properties

--- a/flask_monitoringdashboard/static/js/controllers/endpointProfiler.js
+++ b/flask_monitoringdashboard/static/js/controllers/endpointProfiler.js
@@ -16,7 +16,7 @@ function EndpointProfilerController($scope, $http, menuService, endpointService,
     paginationService.onReload = function () {
         formService.isLoading = true;
         $http.get('api/profiler_table/' + endpointService.info.id + '/' +
-            paginationService.getLeft() + '/' + paginationService.perPage).then(function (response) {
+            paginationService.getLeft() + '/' + paginationService.perPage + '?sortby='+ paginationService.sortby ).then(function (response) {
             $scope.table = response.data;
             formService.isLoading = false;
             // Add more properties

--- a/flask_monitoringdashboard/static/js/services/pagination.js
+++ b/flask_monitoringdashboard/static/js/services/pagination.js
@@ -7,6 +7,7 @@ app.service('paginationService', function () {
         this.name = name;
         this.sortby = "time_requested";
         this.showValue = "Latest";
+        this.response_status = "all";
     };
 
     this.maxPages = function () {
@@ -27,6 +28,11 @@ app.service('paginationService', function () {
     this.updatesort = function (sortby, value) {
         this.sortby = sortby;
         this.showValue = value
+        this.onReload();
+    };
+
+    this.updateStatusCode = function (status) {
+        this.response_status = status;
         this.onReload();
     };
 

--- a/flask_monitoringdashboard/static/js/services/pagination.js
+++ b/flask_monitoringdashboard/static/js/services/pagination.js
@@ -5,7 +5,8 @@ app.service('paginationService', function () {
         this.perPage = 5;
         this.total = 0;
         this.name = name;
-        this.sortby = "latest";
+        this.sortby = "time_requested";
+        this.showValue = "Latest";
     };
 
     this.maxPages = function () {
@@ -23,8 +24,9 @@ app.service('paginationService', function () {
         return Math.min(this.total, this.getLeft() + this.perPage);
     };
 
-    this.updatesort = function (sort) {
-        this.sortby = sort;
+    this.updatesort = function (sortby, value) {
+        this.sortby = sortby;
+        this.showValue = value
         this.onReload();
     };
 

--- a/flask_monitoringdashboard/static/js/services/pagination.js
+++ b/flask_monitoringdashboard/static/js/services/pagination.js
@@ -5,6 +5,7 @@ app.service('paginationService', function () {
         this.perPage = 5;
         this.total = 0;
         this.name = name;
+        this.sortby = "latest";
     };
 
     this.maxPages = function () {
@@ -20,6 +21,11 @@ app.service('paginationService', function () {
 
     this.getRight = function () {
         return Math.min(this.total, this.getLeft() + this.perPage);
+    };
+
+    this.updatesort = function (sort) {
+        this.sortby = sort;
+        this.onReload();
     };
 
     this.getFirstPage = function () {

--- a/flask_monitoringdashboard/static/pages/profiler.html
+++ b/flask_monitoringdashboard/static/pages/profiler.html
@@ -16,6 +16,7 @@
                 <div class="card-header">
                     <div class="row align-items-end">
                         <div class="col-sm"><h6>Request id: {{ request.id }}</h6></div>
+                        <div class="col-sm"><h6>Status Code: {{ request.status_code }}</h6></div>
                         <div class="col-sm"><h6>Request date: {{ request.time_requested | dateLayout }}</h6></div>
                         <div class="col-sm">
                             <button class="btn btn-primary" style="float: right;"

--- a/flask_monitoringdashboard/views/profiler.py
+++ b/flask_monitoringdashboard/views/profiler.py
@@ -20,8 +20,9 @@ def num_profiled(endpoint_id):
 @secure
 def profiler_table(endpoint_id, offset, per_page):
     sort_by = request.args.get('sortby', 'latest')
+    response_status = request.args.get('response_status', 'all').lower()
     with session_scope() as db_session:
-        return jsonify(get_profiler_table(db_session, endpoint_id, offset, per_page, sort_by))
+        return jsonify(get_profiler_table(db_session, endpoint_id, offset, per_page, sort_by, response_status))
 
 
 @blueprint.route('/api/grouped_profiler/<endpoint_id>')

--- a/flask_monitoringdashboard/views/profiler.py
+++ b/flask_monitoringdashboard/views/profiler.py
@@ -1,4 +1,4 @@
-from flask import jsonify
+from flask import jsonify, request
 
 from flask_monitoringdashboard.controllers.profiler import get_profiler_table, get_grouped_profiler
 from flask_monitoringdashboard.database import session_scope
@@ -19,8 +19,9 @@ def num_profiled(endpoint_id):
 @blueprint.route('/api/profiler_table/<endpoint_id>/<offset>/<per_page>')
 @secure
 def profiler_table(endpoint_id, offset, per_page):
+    sort_by = request.args.get('sortby', 'latest')
     with session_scope() as db_session:
-        return jsonify(get_profiler_table(db_session, endpoint_id, offset, per_page))
+        return jsonify(get_profiler_table(db_session, endpoint_id, offset, per_page, sort_by))
 
 
 @blueprint.route('/api/grouped_profiler/<endpoint_id>')


### PR DESCRIPTION
A user can now click on a button to display success calls and failed calls
Status Code range:
success: 100 to 400
failure: 400 to 599


![image](https://user-images.githubusercontent.com/40631675/73650182-8ef31700-46a7-11ea-8a35-964560dbfc27.png)
